### PR TITLE
NOISS Only validate PRs from Forks

### DIFF
--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -3,9 +3,6 @@ name: build module
 on:
   workflow_call:
     inputs:
-      ref:
-        required: true
-        type: string
       module-name:
         required: true
         type: string
@@ -29,8 +26,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          ref: "${{ inputs.ref }}"
 
       - name: setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-www.yml
+++ b/.github/workflows/build-www.yml
@@ -3,9 +3,6 @@ name: build frontend
 on:
   workflow_call:
     inputs:
-      ref:
-        required: true
-        type: string
       build-number:
         required: true
         type: string
@@ -26,8 +23,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,52 +14,74 @@ env:
   BUILD_NUMBER: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
       
 jobs:
+  is-not-fork:
+    runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) }}
+
+    steps:
+      - name: not a fork
+        run: echo "This has been detected to not be running on a fork. Validating and building..."
+
   validate-frontend:
+    if: always()
     uses: iccowan/AviationAPIv2/.github/workflows/validate-www.yml@main
 
   validate:
+    if: always()
     uses: iccowan/AviationAPIv2/.github/workflows/validate.yml@main
 
   validate-tf:
     uses: iccowan/AviationAPIv2/.github/workflows/validate-tf.yml@main
+    needs: is-not-fork
+
+  prepare-variables:
+    runs-on: ubuntu-latest
+    needs: is-not-fork
+    outputs:
+      build-number: ${{ steps.prepare-build-number.outputs.build-number }}
+
+    steps:
+      - name: prepare build number
+        id: prepare-build-number
+        run: echo "build-number=${{ env.BUILD_NUMBER }}" >> "$GITHUB_OUTPUT"
 
   build-frontend:
     uses: iccowan/AviationAPIv2/.github/workflows/build-www.yml@main
-    needs: validate-frontend
+    needs: [validate-frontend, is-not-fork, prepare-variables]
     with:
-      build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      build-number: ${{ needs.prepare-variables.outputs.build-number }}
 
   build-api:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: validate
+    needs: [validate, is-not-fork, prepare-variables]
     with:
       module-name: api
-      build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      build-number: ${{ needs.prepare-variables.outputs.build-number }}
 
   build-chart-pre-processor:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: validate
+    needs: [validate, is-not-fork, prepare-variables]
     with:
       module-name: chart_pre_processor
-      build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      build-number: ${{ needs.prepare-variables.outputs.build-number }}
 
   build-chart-processor:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: validate
+    needs: [validate, is-not-fork, prepare-variables]
     with:
       module-name: chart_processor
-      build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      build-number: ${{ needs.prepare-variables.outputs.build-number }}
 
   build-chart-post-processor:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: validate
+    needs: [validate, is-not-fork, prepare-variables]
     with:
       module-name: chart_post_processor
-      build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      build-number: ${{ needs.prepare-variables.outputs.build-number }}
 
   build-names-summary:
     runs-on: ubuntu-latest
-    needs: [build-frontend, build-api, build-chart-pre-processor, build-chart-processor, build-chart-post-processor]
+    needs: [build-frontend, build-api, build-chart-pre-processor, build-chart-processor, build-chart-post-processor, is-not-fork]
     env:
       OUTPUT_FILE: "output.md"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,83 +7,53 @@ on:
     branches:
       - main
 
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 env:
   BUILD_NUMBER: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
       
 jobs:
-  generate-ref:
-    runs-on: ubuntu-latest
-    outputs:
-      ref: ${{ steps.generate-ref.outputs.ref }}
-
-    steps:
-      - name: generate ref
-        id: generate-ref
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request_target" ]
-          then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
-          fi
-
   validate-frontend:
     uses: iccowan/AviationAPIv2/.github/workflows/validate-www.yml@main
-    needs: generate-ref
-    with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
 
   validate:
     uses: iccowan/AviationAPIv2/.github/workflows/validate.yml@main
-    needs: generate-ref
-    with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
 
   validate-tf:
     uses: iccowan/AviationAPIv2/.github/workflows/validate-tf.yml@main
-    needs: generate-ref
-    with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
 
   build-frontend:
     uses: iccowan/AviationAPIv2/.github/workflows/build-www.yml@main
-    needs: [validate-frontend, generate-ref]
+    needs: validate-frontend
     with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
       build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 
   build-api:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: [validate, generate-ref]
+    needs: validate
     with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
       module-name: api
       build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 
   build-chart-pre-processor:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: [validate, generate-ref]
+    needs: validate
     with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
       module-name: chart_pre_processor
       build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 
   build-chart-processor:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: [validate, generate-ref]
+    needs: validate
     with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
       module-name: chart_processor
       build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 
   build-chart-post-processor:
     uses: iccowan/AviationAPIv2/.github/workflows/build-module.yml@main
-    needs: [validate, generate-ref]
+    needs: validate
     with:
-      ref: ${{ needs.generate-ref.outputs.ref }}
       module-name: chart_post_processor
       build-number: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 

--- a/.github/workflows/deploy-tf.yml
+++ b/.github/workflows/deploy-tf.yml
@@ -18,7 +18,6 @@ jobs:
   plan:
     uses: iccowan/AviationAPIv2/.github/workflows/tf-plan.yml@main
     with:
-      ref: ${{ github.ref }}
       environment: ${{ inputs.environment }}
 
   approve:

--- a/.github/workflows/deploy-tf.yml
+++ b/.github/workflows/deploy-tf.yml
@@ -8,7 +8,6 @@ on:
         type: choice
         options:
           - sandbox
-          - staging
           - prod
 
 permissions:

--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -7,7 +7,6 @@ on:
         type: choice
         options:
           - sandbox
-          - staging
           - prod
       build-name:
         required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
         type: choice
         options:
           - sandbox
-          - staging
           - prod
       build-name:
         required: true

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -3,9 +3,6 @@ name: terraform plan
 on:
   workflow_call:
     inputs:
-      ref:
-        required: true
-        type: string
       environment:
         required: true
         type: string
@@ -24,8 +21,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: setup aws credentials
         uses: ./.github/actions/setup-tf-aws-credentials-action

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -2,10 +2,6 @@ name: validate terraform
 
 on:
   workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
 
 permissions:
   id-token: write
@@ -14,17 +10,14 @@ jobs:
   sandbox:
     uses: iccowan/AviationAPIv2/.github/workflows/tf-plan.yml@main
     with:
-      ref: ${{ inputs.ref }}
       environment: sandbox
 
   staging:
     uses: iccowan/AviationAPIv2/.github/workflows/tf-plan.yml@main
     with:
-      ref: ${{ inputs.ref }}
       environment: staging
 
   prod:
     uses: iccowan/AviationAPIv2/.github/workflows/tf-plan.yml@main
     with:
-      ref: ${{ inputs.ref }}
       environment: prod

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -12,11 +12,6 @@ jobs:
     with:
       environment: sandbox
 
-  staging:
-    uses: iccowan/AviationAPIv2/.github/workflows/tf-plan.yml@main
-    with:
-      environment: staging
-
   prod:
     uses: iccowan/AviationAPIv2/.github/workflows/tf-plan.yml@main
     with:

--- a/.github/workflows/validate-www.yml
+++ b/.github/workflows/validate-www.yml
@@ -2,10 +2,6 @@ name: validate frontend
 
 on:
   workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
 
 jobs:
   check-format:
@@ -14,8 +10,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,10 +2,6 @@ name: validate code
 
 on:
   workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
 
 jobs:
   check-format:
@@ -14,8 +10,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: setup python
         uses: actions/setup-python@v5
@@ -39,8 +33,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: setup python
         uses: actions/setup-python@v5
@@ -57,7 +49,7 @@ jobs:
       - name: run tests
         run: pytest --junit-xml=test-results.xml
         env:
-          AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+          AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: TESTINGANDNOTVALID
           AWS_SECRET_ACCESS_KEY: TESTINGANDNOTVALIDSECRET
 


### PR DESCRIPTION
This PR will:
* Change the PR build workflow to only validate PRs that come from forks
* The process from internal PRs and pushes to main remains the same